### PR TITLE
Bite 1208  - Fix Test Container

### DIFF
--- a/application.bitesize
+++ b/application.bitesize
@@ -213,7 +213,7 @@ applications:
         type: debian-package
         origin:
           build: test-executor-app
-      - name: rubygem-rspec_junit_formatter
+      - name: rubygem-rspec-junit-formatter
         type: debian-package
         origin:
           build: test-executor-app

--- a/application.bitesize
+++ b/application.bitesize
@@ -41,7 +41,7 @@ applications:
         type: debian-package
         origin:
           build: test-executor-app
-      - name: pygithub 
+      - name: pygithub
         type: debian-package
         origin:
           build: test-executor-app
@@ -206,6 +206,14 @@ applications:
         origin:
           build: test-executor-app
       - name: rubygem-sslshake
+        type: debian-package
+        origin:
+          build: test-executor-app
+      - name: rubygem-parallel
+        type: debian-package
+        origin:
+          build: test-executor-app
+      - name: rubygem-rspec_junit_formatter
         type: debian-package
         origin:
           build: test-executor-app

--- a/build.bitesize
+++ b/build.bitesize
@@ -12,7 +12,7 @@ components:
         package: python2.7
     repository:
       git: git@github.com:pearsontechnology/kubernetes-tests.git
-      branch: master
+      branch: bite-1208
     build:
       - shell: mkdir -p var
       - shell: cp -a test-executor-app/testRunner.py var

--- a/build.bitesize
+++ b/build.bitesize
@@ -14,7 +14,7 @@ components:
         package: python2.7
     repository:
       git: git@github.com:pearsontechnology/kubernetes-tests.git
-      branch: master
+      branch: bite-1208 
     build:
       - shell: mkdir -p var
       - shell: cp -a test-executor-app/testRunner.py var

--- a/build.bitesize
+++ b/build.bitesize
@@ -5,8 +5,6 @@ components:
     os: linux
     dependencies:
       - type: gem-package
-        package: rdoc
-      - type: gem-package
         package: fpm
       - type: debian-package
         package: build-essential
@@ -14,7 +12,7 @@ components:
         package: python2.7
     repository:
       git: git@github.com:pearsontechnology/kubernetes-tests.git
-      branch: bite-1208 
+      branch: bite-1208
     build:
       - shell: mkdir -p var
       - shell: cp -a test-executor-app/testRunner.py var

--- a/build.bitesize
+++ b/build.bitesize
@@ -12,7 +12,7 @@ components:
         package: python2.7
     repository:
       git: git@github.com:pearsontechnology/kubernetes-tests.git
-      branch: bite-1208
+      branch: master
     build:
       - shell: mkdir -p var
       - shell: cp -a test-executor-app/testRunner.py var

--- a/build.bitesize
+++ b/build.bitesize
@@ -29,7 +29,7 @@ components:
       - shell: fpm --no-depends -s python -t deb -n futures --iteration $(date "+%Y%m%d%H%M%S") futures
       - shell: fpm --no-depends -s python -t deb -n boto3 --iteration $(date "+%Y%m%d%H%M%S") boto3
       - shell: mkdir gems
-      - shell: gem install --no-ri -v 0.33.0 --no-rdoc --install-dir gems inspec
+      - shell: gem install --no-ri -v 1.7.2 --no-rdoc --install-dir gems inspec
       - shell: find gems/cache -name '*.gem' | xargs -rn1 fpm  --no-depends --iteration $(date "+%Y%m%d%H%M%S") -s gem -t deb
       - shell: git clone https://github.com/sstephenson/bats.git
       - shell: bats/install.sh .

--- a/inspec_tests/controls/test_auth_spec.rb
+++ b/inspec_tests/controls/test_auth_spec.rb
@@ -66,5 +66,5 @@ describe service('tuned') do
 end
 describe mount('/') do
   it { should be_mounted }
-  its('type') { should eq  'ext4' }
+  its('type') { should eq  'xfs' }
 end

--- a/inspec_tests/controls/test_auth_spec.rb
+++ b/inspec_tests/controls/test_auth_spec.rb
@@ -64,3 +64,7 @@ describe service('tuned') do
   it { should be_enabled }
   it { should be_running }
 end
+describe mount('/') do
+  it { should be_mounted }
+  its('type') { should eq  'ext4' }
+end

--- a/inspec_tests/controls/test_etcd_spec.rb
+++ b/inspec_tests/controls/test_etcd_spec.rb
@@ -66,5 +66,5 @@ describe service('tuned') do
 end
 describe mount('/') do
   it { should be_mounted }
-  its('type') { should eq  'ext4' }
+  its('type') { should eq  'xfs' }
 end

--- a/inspec_tests/controls/test_etcd_spec.rb
+++ b/inspec_tests/controls/test_etcd_spec.rb
@@ -64,3 +64,7 @@ describe service('tuned') do
   it { should be_enabled }
   it { should be_running }
 end
+describe mount('/') do
+  it { should be_mounted }
+  its('type') { should eq  'ext4' }
+end

--- a/inspec_tests/controls/test_loadbalancer_spec.rb
+++ b/inspec_tests/controls/test_loadbalancer_spec.rb
@@ -89,3 +89,7 @@ end
 describe file('/etc/hosts') do
   its('content') { should match(%r{172.31.16.3 bitesize-registry.default.svc.cluster.local}) }
 end
+describe mount('/') do
+  it { should be_mounted }
+  its('type') { should eq  'ext4' }
+end

--- a/inspec_tests/controls/test_loadbalancer_spec.rb
+++ b/inspec_tests/controls/test_loadbalancer_spec.rb
@@ -91,5 +91,5 @@ describe file('/etc/hosts') do
 end
 describe mount('/') do
   it { should be_mounted }
-  its('type') { should eq  'ext4' }
+  its('type') { should eq  'xfs' }
 end

--- a/inspec_tests/controls/test_master_spec.rb
+++ b/inspec_tests/controls/test_master_spec.rb
@@ -85,5 +85,5 @@ describe service('tuned') do
 end
 describe mount('/') do
   it { should be_mounted }
-  its('type') { should eq  'ext4' }
+  its('type') { should eq  'xfs' }
 end

--- a/inspec_tests/controls/test_master_spec.rb
+++ b/inspec_tests/controls/test_master_spec.rb
@@ -83,3 +83,7 @@ describe service('tuned') do
   it { should be_enabled }
   it { should be_running }
 end
+describe mount('/') do
+  it { should be_mounted }
+  its('type') { should eq  'ext4' }
+end

--- a/inspec_tests/controls/test_minion_spec.rb
+++ b/inspec_tests/controls/test_minion_spec.rb
@@ -89,3 +89,7 @@ end
 describe file('/etc/hosts') do
   its('content') { should match(%r{172.31.16.3 bitesize-registry.default.svc.cluster.local}) }
 end
+describe mount('/') do
+  it { should be_mounted }
+  its('type') { should eq  'ext4' }
+end

--- a/inspec_tests/controls/test_minion_spec.rb
+++ b/inspec_tests/controls/test_minion_spec.rb
@@ -91,5 +91,5 @@ describe file('/etc/hosts') do
 end
 describe mount('/') do
   it { should be_mounted }
-  its('type') { should eq  'ext4' }
+  its('type') { should eq  'xfs' }
 end

--- a/job-withargs.yaml
+++ b/job-withargs.yaml
@@ -22,7 +22,7 @@ spec:
           secretName: test-runner-secrets
       containers:
       - name: testexecutor
-        image: bitesize-registry.default.svc.cluster.local:5000/test-runner/test-executor-app:1.0.0-20161212193751
+        image: bitesize-registry.default.svc.cluster.local:5000/test-runner/test-executor-app:1.0.0-20161212202651
         volumeMounts:
         - mountPath: /etc/secret-volume
           name: secret-volume

--- a/job-withargs.yaml
+++ b/job-withargs.yaml
@@ -22,7 +22,7 @@ spec:
           secretName: test-runner-secrets
       containers:
       - name: testexecutor
-        image: bitesize-registry.default.svc.cluster.local:5000/test-runner/test-executor-app:1.0.0-20161102223215
+        image: bitesize-registry.default.svc.cluster.local:5000/test-runner/test-executor-app:1.0.0-20161212193751
         volumeMounts:
         - mountPath: /etc/secret-volume
           name: secret-volume

--- a/job-withargs.yaml
+++ b/job-withargs.yaml
@@ -22,7 +22,7 @@ spec:
           secretName: test-runner-secrets
       containers:
       - name: testexecutor
-        image: bitesize-registry.default.svc.cluster.local:5000/test-runner/test-executor-app:1.0.0-20161212202651
+        image: bitesize-registry.default.svc.cluster.local:5000/test-runner/test-executor-app:1.0.0-20161212214120
         volumeMounts:
         - mountPath: /etc/secret-volume
           name: secret-volume

--- a/job.yaml
+++ b/job.yaml
@@ -22,7 +22,7 @@ spec:
           secretName: test-runner-secrets
       containers:
       - name: testexecutor
-        image: bitesize-registry.default.svc.cluster.local:5000/test-runner/test-executor-app:1.0.0-20161212193751
+        image: bitesize-registry.default.svc.cluster.local:5000/test-runner/test-executor-app:1.0.0-20161212202651
         volumeMounts:
         - mountPath: /etc/secret-volume
           name: secret-volume

--- a/job.yaml
+++ b/job.yaml
@@ -22,7 +22,7 @@ spec:
           secretName: test-runner-secrets
       containers:
       - name: testexecutor
-        image: bitesize-registry.default.svc.cluster.local:5000/test-runner/test-executor-app:1.0.0-20161102223215
+        image: bitesize-registry.default.svc.cluster.local:5000/test-runner/test-executor-app:1.0.0-20161212193751
         volumeMounts:
         - mountPath: /etc/secret-volume
           name: secret-volume

--- a/job.yaml
+++ b/job.yaml
@@ -22,7 +22,7 @@ spec:
           secretName: test-runner-secrets
       containers:
       - name: testexecutor
-        image: bitesize-registry.default.svc.cluster.local:5000/test-runner/test-executor-app:1.0.0-20161212202651
+        image: bitesize-registry.default.svc.cluster.local:5000/test-runner/test-executor-app:1.0.0-20161212214120
         volumeMounts:
         - mountPath: /etc/secret-volume
           name: secret-volume

--- a/test-executor-app/testRunner.py
+++ b/test-executor-app/testRunner.py
@@ -20,6 +20,7 @@ failuresReceived = False
 GIT_USERNAME = os.environ['GIT_USERNAME']
 GIT_PASSWORD = os.environ['GIT_PASSWORD']
 GIT_REPO = os.environ['GIT_REPO']
+GIT_BRANCH = os.environ['GIT_BRANCH']
 
 g = Github(GIT_USERNAME, GIT_PASSWORD)
 
@@ -31,7 +32,7 @@ def clone_repo(name, url, directory):
     location_with_password = '{0}:{1}@{2}'.format(encoded_username, encoded_password, netloc)
     parts = parts._replace(netloc=location_with_password)
     auth_url = parts.geturl()
-    command = "git clone " + auth_url + " " + directory
+    command = "git clone --branch " + GIT_BRANCH + " " + auth_url + " " + directory
     print("Cloning Repo = {0}".format(command))
     run_script(command,True)
 


### PR DESCRIPTION
Our test container was not appropriately pulling branches.  This change upgrades the version of INSPEC to 1.7.2 but also fixes a bug with cloning of kubernetes-test branches.

Verify: See Bitesize PR