### PR TITLE
Cops 462 - Added sysdig-agent test

### DIFF
--- a/bats_tests/test_ingresses.bats
+++ b/bats_tests/test_ingresses.bats
@@ -18,6 +18,6 @@ load helpers
   kubectl get ing grafana --namespace=default --no-headers
 }
 
-@test "es ingress" {
-  kubectl get ing es-ingress --namespace=default --no-headers
-}
+#@test "es ingress" {
+#  kubectl get ing es-ingress --namespace=default --no-headers
+#}

--- a/bats_tests/test_pod_counts.bats
+++ b/bats_tests/test_pod_counts.bats
@@ -28,23 +28,23 @@ load helpers
   values_equal $VAULT_DESIRED $VAULT_CURRENT
 }
 
-@test "es-master pods" {
-  ES_MASTER_DESIRED=`kubectl get deployments es-master --namespace=default -o jsonpath='{.spec.replicas}'`
-  ES_MASTER_CURRENT=`kubectl get deployments es-master --namespace=default -o jsonpath='{.status.replicas}'`
-  values_equal $ES_MASTER_DESIRED $ES_MASTER_CURRENT
-}
-
-@test "es-data pods" {
-  ES_DATA_DESIRED=`kubectl get deployments es-data --namespace=default -o jsonpath='{.spec.replicas}'`
-  ES_DATA_CURRENT=`kubectl get deployments es-data --namespace=default -o jsonpath='{.status.replicas}'`
-  values_equal $ES_DATA_DESIRED $ES_DATA_CURRENT
-}
-
-@test "es-client pods" {
-  ES_CLIENT_DESIRED=`kubectl get deployments es-client --namespace=default -o jsonpath='{.spec.replicas}'`
-  ES_CLIENT_CURRENT=`kubectl get deployments es-client --namespace=default -o jsonpath='{.status.replicas}'`
-  values_equal $ES_CLIENT_DESIRED $ES_CLIENT_CURRENT
-}
+# @test "es-master pods" {
+#   ES_MASTER_DESIRED=`kubectl get deployments es-master --namespace=default -o jsonpath='{.spec.replicas}'`
+#   ES_MASTER_CURRENT=`kubectl get deployments es-master --namespace=default -o jsonpath='{.status.replicas}'`
+#   values_equal $ES_MASTER_DESIRED $ES_MASTER_CURRENT
+# }
+#
+# @test "es-data pods" {
+#   ES_DATA_DESIRED=`kubectl get deployments es-data --namespace=default -o jsonpath='{.spec.replicas}'`
+#   ES_DATA_CURRENT=`kubectl get deployments es-data --namespace=default -o jsonpath='{.status.replicas}'`
+#   values_equal $ES_DATA_DESIRED $ES_DATA_CURRENT
+# }
+#
+# @test "es-client pods" {
+#   ES_CLIENT_DESIRED=`kubectl get deployments es-client --namespace=default -o jsonpath='{.spec.replicas}'`
+#   ES_CLIENT_CURRENT=`kubectl get deployments es-client --namespace=default -o jsonpath='{.status.replicas}'`
+#   values_equal $ES_CLIENT_DESIRED $ES_CLIENT_CURRENT
+# }
 
 @test "monitoring-heapster-v6 pods" {
   HEAPSTER_DESIRED=`kubectl get rc monitoring-heapster-v6 --namespace=kube-system -o jsonpath='{.spec.replicas}'`

--- a/bats_tests/test_services.bats
+++ b/bats_tests/test_services.bats
@@ -34,13 +34,13 @@ load helpers
   kubectl get svc vault --namespace=kube-system --no-headers
 }
 
-@test "elasticsearch service" {
-  kubectl get svc elasticsearch --namespace=default --no-headers
-}
-
-@test "elasticsearch-discovery service" {
-  kubectl get svc elasticsearch-discovery --namespace=default --no-headers
-}
+# @test "elasticsearch service" {
+#   kubectl get svc elasticsearch --namespace=default --no-headers
+# }
+#
+# @test "elasticsearch-discovery service" {
+#   kubectl get svc elasticsearch-discovery --namespace=default --no-headers
+# }
 
 @test "monitoring-heapster service" {
   kubectl get svc monitoring-heapster --namespace=kube-system --no-headers

--- a/bats_tests/test_user_pods.bats
+++ b/bats_tests/test_user_pods.bats
@@ -10,17 +10,17 @@ load helpers
   kubectl get pods --namespace=default --no-headers | grep bitesize-registry | grep Running
 }
 
-@test "es-master" {
-  kubectl get pods --namespace=default --no-headers | grep es-master | grep Running
-}
-
-@test "es-data" {
-  kubectl get pods --namespace=default --no-headers | grep es-data | grep Running
-}
-
-@test "es-client" {
-  kubectl get pods --namespace=default --no-headers | grep es-client | grep Running
-}
+# @test "es-master" {
+#   kubectl get pods --namespace=default --no-headers | grep es-master | grep Running
+# }
+#
+# @test "es-data" {
+#   kubectl get pods --namespace=default --no-headers | grep es-data | grep Running
+# }
+#
+# @test "es-client" {
+#   kubectl get pods --namespace=default --no-headers | grep es-client | grep Running
+# }
 
 @test "kube-dns" {
   kubectl get pods --namespace=kube-system --no-headers | grep kube-dns | grep Running
@@ -38,10 +38,10 @@ load helpers
   kubectl get pods --namespace=kube-system --no-headers | grep vault | grep Running
 }
 
-# Test Elasticsearch cluster is up and green
-@test "elasticsearch-default-svc-cluster-local" {
-  curl --connect-timeout 30 --max-time 60 http://elasticsearch.default.svc.cluster.local:9200/_cluster/health | grep status | grep green
-}
+# # Test Elasticsearch cluster is up and green
+# @test "elasticsearch-default-svc-cluster-local" {
+#   curl --connect-timeout 30 --max-time 60 http://elasticsearch.default.svc.cluster.local:9200/_cluster/health | grep status | grep green
+# }
 
 @test "td-agent-es" {
   kubectl get pods --namespace=kube-system --no-headers | grep td-agent-es | grep Running

--- a/bats_tests/test_user_pods.bats
+++ b/bats_tests/test_user_pods.bats
@@ -46,3 +46,7 @@ load helpers
 @test "td-agent-es" {
   kubectl get pods --namespace=kube-system --no-headers | grep td-agent-es | grep Running
 }
+
+@test "sysdig-agent" {
+  kubectl get pods --namespace=kube-system --no-headers | grep sysdig-agent | grep Running
+}

--- a/bats_tests/test_user_pods.bats
+++ b/bats_tests/test_user_pods.bats
@@ -47,7 +47,6 @@ load helpers
   kubectl get pods --namespace=kube-system --no-headers | grep td-agent-es | grep Running
 }
 
-# Disable sysdig-agent test until kernel development header fix in AMI
-# @test "sysdig-agent" {
-#   kubectl get pods --namespace=kube-system --no-headers | grep sysdig-agent | grep Running
-# }
+@test "sysdig-agent" {
+  kubectl get pods --namespace=kube-system --no-headers | grep sysdig-agent | grep Running
+}

--- a/bats_tests/test_user_pods.bats
+++ b/bats_tests/test_user_pods.bats
@@ -47,6 +47,7 @@ load helpers
   kubectl get pods --namespace=kube-system --no-headers | grep td-agent-es | grep Running
 }
 
-@test "sysdig-agent" {
-  kubectl get pods --namespace=kube-system --no-headers | grep sysdig-agent | grep Running
-}
+# Disable sysdig-agent test until kernel development header fix in AMI
+# @test "sysdig-agent" {
+#   kubectl get pods --namespace=kube-system --no-headers | grep sysdig-agent | grep Running
+# }


### PR DESCRIPTION
- Added sysdig-agent test in user_pod test.
- Removed all Elasticsearch cluster tests including pods, services, counts and ingress. We are not using the Elasticsearch cluster in the PaaS but the AWS Elasticsearch Service right now.

Changes are tested by : https://github.com/pearsontechnology/bitesize/pull/771