### PR TITLE
test-master check only test-st2-sensor for now

### DIFF
--- a/bats_tests/test_testmaster.bats
+++ b/bats_tests/test_testmaster.bats
@@ -3,7 +3,7 @@
 set -o pipefail
 
 # Services
-
+# Temporarily modified to only check for test-tpr-s3.
 @test "Verify that all test services are running successfully" {
-    curl -s -o /dev/null -w "%{http_code}" test-master.default.svc.cluster.local/services | grep 200
+    curl -s -o /dev/null -w "%{http_code}" test-master.default.svc.cluster.local/service/test-st2-sensor | grep 200
 }


### PR DESCRIPTION
This is because test-tpr-s3 is pointing at a non-prod s3 bucket in prod environment. This will be reverted when test-tpr-s3 is fixed.