### PR TITLE
[COPS-679] - Tests for SMTP settings in Grafana

### DIFF
--- a/bats_tests/test_grafana_smtp.bats
+++ b/bats_tests/test_grafana_smtp.bats
@@ -1,0 +1,13 @@
+#!/usr/bin/env bats
+
+set -o pipefail
+
+load helpers
+
+
+@test "grafana smtp" {
+    # curl -k --user admin:${KUBE_PASS} -H "Content-Type: application/json" "http://grafana.default.svc.cluster.local:3000/api/alert-notifications/test" -d '{"name":"Grafana-test-email","type":"email","settings":{"addresses":"cloudops@pearson.com"}}' | grep "Test notification sent" 
+    curl -k --user admin:${KUBE_PASS} -H "Content-Type: application/json" "http://grafana.default.svc.cluster.local:3000/api/alert-notifications/test" -d '{"name":"Grafana-test-email","type":"email","settings":{"addresses":"thilina.piyasundara@pearson.com"}}' | grep "Test notification sent" 
+
+}
+


### PR DESCRIPTION
I have update the grafana-rc to include SMTP settings in bitesize code. If that is correctly configured users should be able to successfully send a test mail via that. In the test case I'm doing the same thing using Grafana http-apis via a curl command.