### PR TITLE
BITE-1823 use filter to list Cloudwatch log groups

### DIFF
--- a/python_tests/test_cloudwatch_flowlogs.py
+++ b/python_tests/test_cloudwatch_flowlogs.py
@@ -14,21 +14,20 @@ def test_cloudwatch_flowlog_log_groups_exist():
     logs = boto3.client('logs', region_name=os.environ["REGION"])
     env = os.environ["ENVIRONMENT"]
     log_group_count = 0
-    log_groups = logs.describe_log_groups()
+    log_groups = logs.describe_log_groups(logGroupNamePrefix='/bitesize-' + env)
     for log in log_groups ['logGroups']:
-        if (env in log['logGroupName']) and log['logGroupName'].startswith("/bitesize"):
-            if log['logGroupName'].endswith("/flowlog"):
-                log_group_count += 1
+        if log['logGroupName'].endswith("/flowlog"):
+            log_group_count += 1
     assert log_group_count == 2   #should be a flowlog log group for the Bitesize VPC and another for the database VPC
 
 ##Verify flowlog log streams written to flowlog log group for Bitesize VPC
 def test_cloudwatch_flowlog_log_streams():
     logs = boto3.client('logs', region_name=os.environ["REGION"])
     env = os.environ["ENVIRONMENT"]
-    log_groups = logs.describe_log_groups()
+    log_groups = logs.describe_log_groups(logGroupNamePrefix='/bitesize-' + env)
     syslog_log_stream_count = 0
     for log_group in log_groups ['logGroups']:
-        if (env in log_group['logGroupName']) and log_group['logGroupName'].startswith("/bitesize") and log_group['logGroupName'].endswith("/flowlog"):
+        if (log_group['logGroupName'].endswith("/flowlog")):
             log_stream_data = logs.describe_log_streams(logGroupName = log_group['logGroupName'])
             for log_stream in log_stream_data['logStreams']:
                 if (log_stream['logStreamName'].startswith("eni")):

--- a/python_tests/test_cloudwatch_os_logs.py
+++ b/python_tests/test_cloudwatch_os_logs.py
@@ -7,23 +7,22 @@ def test_cloudwatch_os_log_groups_exist():
     logs = boto3.client('logs', region_name=os.environ["REGION"])
     env = os.environ["ENVIRONMENT"]
     log_group_count = 0
-    log_groups = logs.describe_log_groups()
+    log_groups = logs.describe_log_groups(logGroupNamePrefix='/bitesize-' + env)
     for log in log_groups['logGroups']:
-        if (env in log['logGroupName']) and log['logGroupName'].startswith("/bitesize"):
-            if log['logGroupName'].endswith("/audit"):
-                log_group_count += 1
-            if log['logGroupName'].endswith("/syslog"):
-                log_group_count += 1
+        if log['logGroupName'].endswith("/audit"):
+            log_group_count += 1
+        if log['logGroupName'].endswith("/syslog"):
+            log_group_count += 1
     assert log_group_count == 4   #should be a total of 4 Cloudwatch audit and syslog log groups
 
 ##Verify audit log streams written to Cloudwatch log groups
 def test_cloudwatch_audit_log_streams():
     logs = boto3.client('logs', region_name=os.environ["REGION"])
     env = os.environ["ENVIRONMENT"]
-    log_groups = logs.describe_log_groups()
+    log_groups = logs.describe_log_groups(logGroupNamePrefix='/bitesize-' + env)
     audit_log_stream_count = 0
     for log_group in log_groups ['logGroups']:
-        if (env in log_group['logGroupName']) and log_group['logGroupName'].startswith("/bitesize") and log_group['logGroupName'].endswith("/audit"):
+        if (log_group['logGroupName'].endswith("/audit")):
             log_stream_data = logs.describe_log_streams(logGroupName = log_group['logGroupName'])
             for log_stream in log_stream_data['logStreams']:
                 if (log_stream['logStreamName'].startswith("10.") or log_stream['logStreamName'].startswith("172.")):
@@ -34,10 +33,10 @@ def test_cloudwatch_audit_log_streams():
 def test_cloudwatch_syslog_log_streams():
     logs = boto3.client('logs', region_name=os.environ["REGION"])
     env = os.environ["ENVIRONMENT"]
-    log_groups = logs.describe_log_groups()
+    log_groups = logs.describe_log_groups(logGroupNamePrefix='/bitesize-' + env)
     syslog_log_stream_count = 0
     for log_group in log_groups ['logGroups']:
-        if (env in log_group['logGroupName']) and log_group['logGroupName'].startswith("/bitesize") and log_group['logGroupName'].endswith("/syslog"):
+        if (log_group['logGroupName'].endswith("/syslog")):
             log_stream_data = logs.describe_log_streams(logGroupName = log_group['logGroupName'])
             for log_stream in log_stream_data['logStreams']:
                 if (log_stream['logStreamName'].startswith("10.") or log_stream['logStreamName'].startswith("172.")):


### PR DESCRIPTION
https://agile-jira.pearson.com/browse/BITE-1823
There are currently occasional errors in kubernetes-tests on the Cloudwatch log group tests.

This is due to the fact that the boto3 action DescribeLogGroups has a limit of 50 records, however there are typically more than this in Bitesize NonProd eu-west-1

Therefore depending on the alphanumeric order in which results are returned from AWS, the tests may randomly fail

This PR implements a filter within Boto3 describe_log_groups to only retrieve the log groups relevant to the environment being tested